### PR TITLE
カテゴリが新規作成できないバグ

### DIFF
--- a/lib/lokka/app.rb
+++ b/lib/lokka/app.rb
@@ -266,7 +266,7 @@ module Lokka
     post '/admin/categories' do
       login_required
       @category = Category.new(params['category'])
-      @category.user = current_user
+      #@category.user = current_user
       if @category.save
         redirect '/admin/categories'
       else

--- a/public/admin/categories/new.haml
+++ b/public/admin/categories/new.haml
@@ -1,5 +1,5 @@
 %h2= t.new_category
-%form{:action => '/admin/categories', :method => 'category'}
+%form{:action => '/admin/categories', :method => 'post'}
   = partial 'categories/form'
   %p
     %input{:type => 'submit', :value => t.new}


### PR DESCRIPTION
カテゴリを新規作成できないバグがありましたので、修正してみました。
1. public/admin/categories/new.hamlのmethodがpostになっていないため、getに遷移していました。
2. Categoryモデルにuserフィールドがないのに、代入しようとしていました。

お忙しいところ恐縮ですが、よろしくお願い申し上げます。
