### PR TITLE
Modifed Google Analytics plugin to enable to set the domain name

### DIFF
--- a/public/plugin/lokka-google_analytics/lib/lokka/google_analytics.rb
+++ b/public/plugin/lokka-google_analytics/lib/lokka/google_analytics.rb
@@ -7,6 +7,7 @@ module Lokka
 
       app.put '/admin/plugins/google_analytics' do
         Option.tracker = params['tracker']
+        Option.tracker_dn = params['tracker_dn']
         flash[:notice] = 'Updated.'
         redirect '/admin/plugins/google_analytics'
       end
@@ -14,8 +15,12 @@ module Lokka
       app.before do
         tracker = Option.tracker
         if !tracker.blank? and ENV['RACK_ENV'] == 'production' and !logged_in?
+          dn = Option.tracker_dn
+          tracker_script = "<script type=\"text/javascript\">var _gaq=_gaq||[];_gaq.push(['_setAccount','#{tracker}']);"
+          tracker_script += "_gaq.push(['_setDomainName', '.#{dn}']);" unless dn.blank?
+          tracker_script += "_gaq.push(['_trackPageview']);(function(){var ga=document.createElement('script');ga.type='text/javascript';ga.async=true;ga.src=('https:'==document.location.protocol?'https://ssl':'http://www')+'.google-analytics.com/ga.js';var s=document.getElementsByTagName('script')[0];s.parentNode.insertBefore(ga,s);})();</script>"
           content_for :header do
-            "<script type=\"text/javascript\">var _gaq=_gaq||[];_gaq.push(['_setAccount','#{tracker}']);_gaq.push(['_trackPageview']);(function(){var ga=document.createElement('script');ga.type='text/javascript';ga.async=true;ga.src=('https:'==document.location.protocol?'https://ssl':'http://www')+'.google-analytics.com/ga.js';var s=document.getElementsByTagName('script')[0];s.parentNode.insertBefore(ga,s);})();</script>"
+            tracker_script
           end
         end
       end

--- a/public/plugin/lokka-google_analytics/views/index.haml
+++ b/public/plugin/lokka-google_analytics/views/index.haml
@@ -8,4 +8,8 @@
     %br
     %input{:type => 'text', :id => 'post_title', :name => 'tracker', :value => Option.tracker}
   .field
+    %label{:for => 'dn_title'} Domain Name (Optional)
+    %br
+    %input{:type => 'text', :id => 'dn_title', :name => 'tracker_dn', :value => Option.tracker_dn}
+  .field
     %input{:type => 'submit', :value => t.edit}


### PR DESCRIPTION
In the Google Analytics tracking code, if there were more than one subdomain, like 'foo.heroku.com', 'bar.heroku.com' and etc., you have to set the domain name.

The current Google Analytics plugin can't set the domain name. This patch will enable to set the domain name for an option. If the domain name was set, following JS will be added to the tracking code.

_gaq.push(['_setDomainName', '.heroku.com']);
