### PR TITLE
Fixed to add plugins

### DIFF
--- a/lib/lokka/app.rb
+++ b/lib/lokka/app.rb
@@ -26,7 +26,7 @@ module Lokka
         names.map do |name|
           plugins << OpenStruct.new(
             :name => name,
-            :have_admin_page => matchers.any? { |m| m =~ "/admin/plugins/#{name}" })
+            :have_admin_page => matchers.any? {|m| m =~ "/admin/plugins/#{name}" })
         end
       end
       set :plugins, plugins


### PR DESCRIPTION
Current load_plugin method does not set "plugins" array variable. This patch will fix the problem, and it will render plugin list in "http://localhost:9292/admin/plugins".
