### PR TITLE
fixed: if (page|post).user.nil?, it causes NoMethodError

### DIFF
--- a/public/admin/pages/index.haml
+++ b/public/admin/pages/index.haml
@@ -9,7 +9,7 @@
     %tr{:class => (i+1).odd? ? 'odd' : 'even'}
       %td.title
         %a{:href => page.link}= page.title
-      %td= page.user.name
+      %td= page.user.nil? ? '' : page.user.name
       %td= l page.created_at.to_time
       %td
         %a.button{:href => page.edit_link}= t.edit

--- a/public/admin/posts/index.haml
+++ b/public/admin/posts/index.haml
@@ -9,7 +9,7 @@
     %tr{:class => (i+1).odd? ? 'odd' : 'even'}
       %td.title
         %a{:href => post.link}= post.title
-      %td= post.user.name
+      %td= post.user.nil? ? '' : post.user.name
       %td= l post.created_at.to_time
       %td
         %a.button{:href => post.edit_link}= t.edit


### PR DESCRIPTION
after delete a user who has some posts or pages, 
/admin/pages or /admin/posts causes NoMethodError
 #=> NoMethodError - undefined method `name' for nil:NilClass:
