### PR TITLE
Fix an error in generating index.atom

### DIFF
--- a/public/system/index.builder
+++ b/public/system/index.builder
@@ -18,7 +18,7 @@ xml.feed(:xmlns => 'http://www.w3.org/2005/Atom') do
       xml.link      :type => 'html', :rel => 'alternate', :href => base_url + post.link
       xml.content   post.body, :type => 'html'
       xml.author do
-        xml.name post.user.name
+        xml.name post.user.nil? ? '' : post.user.name
       end
     end
   end


### PR DESCRIPTION
初回起動後、自分のアカウントを作り、ユーザー test を削除すると、デフォルトページの Test Post のユーザーがいなくなったせいで、index.atom の生成に失敗するのを修正しました。
