### PR TITLE
update sinatra 1.2.3 to 1.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,10 @@
 source :rubygems
 
 gem 'bundler', '~> 1.0.7'
+gem 'rack', '1.3.2'
 gem 'rack-flash', '0.1.1'
 gem 'i18n', '0.5.0'
-gem 'sinatra', '1.2.3'
+gem 'sinatra', '1.3.0'
 gem 'sinatra-r18n', '0.4.9'
 gem 'sinatra-content-for', '0.2'
 gem 'dm-core',          '1.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,8 @@ GEM
     rack (1.3.2)
     rack-flash (0.1.1)
       rack
+    rack-protection (1.1.2)
+      rack
     rack-test (0.6.0)
       rack (>= 1.0)
     rake (0.8.7)
@@ -107,9 +109,10 @@ GEM
       multi_json (~> 1.0.3)
       simplecov-html (~> 0.5.3)
     simplecov-html (0.5.3)
-    sinatra (1.2.3)
-      rack (~> 1.1)
-      tilt (< 2.0, >= 1.2.2)
+    sinatra (1.3.0)
+      rack (~> 1.3)
+      rack-protection (~> 1.1)
+      tilt (~> 1.3)
     sinatra-content-for (0.2)
       sinatra
     sinatra-r18n (0.4.9)
@@ -119,7 +122,7 @@ GEM
       tilt (~> 1.2)
     stringex (1.2.2)
     temple (0.2.0)
-    tilt (1.3.2)
+    tilt (1.3.3)
     tux (0.3.0)
       ripl (>= 0.3.5)
       ripl-multi_line (>= 0.2.4)
@@ -151,13 +154,14 @@ DEPENDENCIES
   haml (= 3.1.1)
   i18n (= 0.5.0)
   nokogiri
+  rack (= 1.3.2)
   rack-flash (= 0.1.1)
   rack-test (= 0.6.0)
   rake (= 0.8.7)
   rspec (~> 2.5)
   sass (= 3.1.1)
   simplecov
-  sinatra (= 1.2.3)
+  sinatra (= 1.3.0)
   sinatra-content-for (= 0.2)
   sinatra-r18n (= 0.4.9)
   slim (= 0.9.2)

--- a/lib/lokka/app.rb
+++ b/lib/lokka/app.rb
@@ -40,9 +40,9 @@ module Lokka
       register Sinatra::R18n
       register Lokka::Before
       set :root, File.expand_path('../../..', __FILE__)
-      set :public => Proc.new { File.join(root, 'public') }
-      set :views => Proc.new { public }
-      set :theme => Proc.new { File.join(public, 'theme') }
+      set :public_folder => Proc.new { File.join(root, 'public') }
+      set :views => Proc.new { public_folder }
+      set :theme => Proc.new { File.join(public_folder, 'theme') }
       set :supported_templates => %w(erb haml slim erubis)
       set :supported_stylesheet_templates => %w(scss sass)
       set :per_page, 10


### PR DESCRIPTION
sinatra 1.3.0がリリースされたので対応させてみましたがいかがでしょうか
sinatraのpublicディレクトリを指定するための名前がpublicからpublic_folderに変わっているためその対応をおこなっています
