### PR TITLE
Fixed the bug that comments of WordPress were not imported to Lokka.

### DIFF
--- a/lib/lokka/comment.rb
+++ b/lib/lokka/comment.rb
@@ -10,7 +10,7 @@ class Comment
   property :entry_id, Integer
   property :status, Integer # 0 => moderated, 1 => approved
   property :name, String
-  property :email, String, :length => (5..40), :format => :email_address
+  property :email, String, :length => (0..40), :format => :email_address
   property :homepage, String
   property :body, Text
   property :created_at, DateTime

--- a/lib/lokka/importer.rb
+++ b/lib/lokka/importer.rb
@@ -68,20 +68,20 @@ module Lokka
               end
             end
 
+            entry.save
+
             entry.comments.destroy
 
             item.xpath('wp:comment').each do |comment|
-              comment = Comment.new(
+              comment = entry.comments.new(
                 :name => comment.xpath('wp:comment_author').text,
                 :email => comment.xpath('wp:comment_email').text,
                 :body => comment.xpath('wp:comment_content').text,
                 :created_at => comment.xpath('wp:comment_date').text,
                 :status => comment.xpath('wp:comment_approvied').text == '1' ? 1 : 0
               )
-              entry.comments << comment
+              comment.save
             end
-
-            entry.save
           end
         end
       end


### PR DESCRIPTION
- メールアドレスが空欄のコメントでもインポートできるようにした修正
- entry.save をおこなってから comment オブジェクトを save する修正

の2点が含まれています。
