### PR TITLE
Datamapper1.2.0.rc2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,16 +7,16 @@ gem 'i18n', '0.5.0'
 gem 'sinatra', '1.3.0'
 gem 'sinatra-r18n', '0.4.9'
 gem 'sinatra-content-for', '0.2'
-gem 'dm-core',          '1.1.0'
-gem 'dm-migrations',    '1.1.0'
-gem 'dm-timestamps',    '1.1.0'
-gem 'dm-validations',   '1.1.0'
-gem 'dm-types',:git => 'git://github.com/datamapper/dm-types.git', :ref => '62efa7554452a29c'
-gem 'dm-is-tree',       '1.1.0'
-gem 'dm-tags', :git => 'git://github.com/komagata/dm-tags.git'
-gem 'dm-pager',         '1.1.0'
-gem 'dm-is-searchable', '1.1.0'
-gem 'dm-do-adapter', :git => 'git://github.com/yayugu/dm-do-adapter.git', :branch => '1.1.0.fix'
+gem 'dm-core',          '1.2.0.rc2'
+gem 'dm-migrations',    '1.2.0.rc2'
+gem 'dm-timestamps',    '1.2.0.rc2'
+gem 'dm-validations',   '1.2.0.rc2'
+gem 'dm-types',         '1.2.0.rc2'
+gem 'dm-is-tree',       '1.2.0.rc2'
+gem 'dm-tags',          '1.2.0.rc2' 
+gem 'dm-is-searchable', '1.2.0.rc2'
+gem 'dm-pager',         :git => 'git://github.com/yayugu/dm-pagination.git'
+gem 'dm-aggregates',    '1.2.0.rc2'
 gem 'builder', '3.0.0'
 gem 'haml', '3.1.1'
 gem 'sass', '3.1.1'
@@ -30,12 +30,12 @@ gem 'tux'
 Dir["public/plugin/lokka-*/Gemfile"].each {|path| eval(open(path) {|f| f.read }) }
 
 group :production do
-  gem 'dm-postgres-adapter', '1.1.0'
-  gem 'dm-mysql-adapter', '1.1.0'
+  gem 'dm-postgres-adapter', '1.2.0.rc2'
+  gem 'dm-mysql-adapter', '1.2.0.rc2'
 end
 
 group :development, :test do
-  gem 'dm-sqlite-adapter', '1.1.0'
+  gem 'dm-sqlite-adapter', '1.2.0.rc2'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,8 @@
 GIT
-  remote: git://github.com/datamapper/dm-types.git
-  revision: 62efa7554452a29cf1c501ae72d7d3d9ef4db619
-  ref: 62efa7554452a29c
+  remote: git://github.com/yayugu/dm-pagination.git
+  revision: ab6e85d1b9e7d8d8ee69921bd0796f20d34a5e89
   specs:
-    dm-types (1.1.1)
-      bcrypt-ruby (~> 3.0.0)
-      dm-core (~> 1.1.0)
-      fastercsv (~> 1.5.4)
-      json (~> 1.5.4)
-      multi_json (~> 1.0.3)
-      stringex (~> 1.3.0)
-      uuidtools (~> 2.1.2)
-
-GIT
-  remote: git://github.com/komagata/dm-tags.git
-  revision: 04909e276669367fd1a5174429d0bb26b8b67ae6
-  specs:
-    dm-tags (1.1.1)
-      dm-core (~> 1.1.0)
-
-GIT
-  remote: git://github.com/yayugu/dm-do-adapter.git
-  revision: 65d9a814a7be1d76670fee10031d88cc487dac10
-  branch: 1.1.0.fix
-  specs:
-    dm-do-adapter (1.1.0)
-      data_objects (~> 0.10.2)
-      dm-core (~> 1.1.0)
+    dm-pager (1.1.1)
 
 GEM
   remote: http://rubygems.org/
@@ -40,32 +16,42 @@ GEM
     data_objects (0.10.6)
       addressable (~> 2.1)
     diff-lcs (1.1.3)
-    dm-aggregates (1.1.0)
-      dm-core (~> 1.1.0)
-    dm-core (1.1.0)
-      addressable (~> 2.2.4)
-    dm-is-searchable (1.1.0)
-      dm-core (~> 1.1.0)
-    dm-is-tree (1.1.0)
-      dm-core (~> 1.1.0)
-    dm-migrations (1.1.0)
-      dm-core (~> 1.1.0)
-    dm-mysql-adapter (1.1.0)
-      dm-do-adapter (~> 1.1.0)
-      do_mysql (~> 0.10.2)
-    dm-pager (1.1.0)
-      dm-aggregates (>= 0.10.1)
-      dm-core (>= 0.10.1)
-    dm-postgres-adapter (1.1.0)
-      dm-do-adapter (~> 1.1.0)
-      do_postgres (~> 0.10.2)
-    dm-sqlite-adapter (1.1.0)
-      dm-do-adapter (~> 1.1.0)
-      do_sqlite3 (~> 0.10.2)
-    dm-timestamps (1.1.0)
-      dm-core (~> 1.1.0)
-    dm-validations (1.1.0)
-      dm-core (~> 1.1.0)
+    dm-aggregates (1.2.0.rc2)
+      dm-core (~> 1.2.0.rc2)
+    dm-core (1.2.0.rc2)
+      addressable (~> 2.2.6)
+    dm-do-adapter (1.2.0.rc2)
+      data_objects (~> 0.10.6)
+      dm-core (~> 1.2.0.rc2)
+    dm-is-searchable (1.2.0.rc2)
+      dm-core (~> 1.2.0.rc2)
+    dm-is-tree (1.2.0.rc2)
+      dm-core (~> 1.2.0.rc2)
+    dm-migrations (1.2.0.rc2)
+      dm-core (~> 1.2.0.rc2)
+    dm-mysql-adapter (1.2.0.rc2)
+      dm-do-adapter (~> 1.2.0.rc2)
+      do_mysql (~> 0.10.6)
+    dm-postgres-adapter (1.2.0.rc2)
+      dm-do-adapter (~> 1.2.0.rc2)
+      do_postgres (~> 0.10.6)
+    dm-sqlite-adapter (1.2.0.rc2)
+      dm-do-adapter (~> 1.2.0.rc2)
+      do_sqlite3 (~> 0.10.6)
+    dm-tags (1.2.0.rc2)
+      dm-core (~> 1.2.0.rc2)
+    dm-timestamps (1.2.0.rc2)
+      dm-core (~> 1.2.0.rc2)
+    dm-types (1.2.0.rc2)
+      bcrypt-ruby (~> 3.0.0)
+      dm-core (~> 1.2.0.rc2)
+      fastercsv (~> 1.5.4)
+      json (~> 1.5.4)
+      multi_json (~> 1.0.3)
+      stringex (~> 1.3.0)
+      uuidtools (~> 2.1.2)
+    dm-validations (1.2.0.rc2)
+      dm-core (~> 1.2.0.rc2)
     do_mysql (0.10.6)
       data_objects (= 0.10.6)
     do_postgres (0.10.6)
@@ -138,19 +124,19 @@ DEPENDENCIES
   activesupport (= 3.0.7)
   builder (= 3.0.0)
   bundler (~> 1.0.7)
-  dm-core (= 1.1.0)
-  dm-do-adapter!
-  dm-is-searchable (= 1.1.0)
-  dm-is-tree (= 1.1.0)
-  dm-migrations (= 1.1.0)
-  dm-mysql-adapter (= 1.1.0)
-  dm-pager (= 1.1.0)
-  dm-postgres-adapter (= 1.1.0)
-  dm-sqlite-adapter (= 1.1.0)
-  dm-tags!
-  dm-timestamps (= 1.1.0)
-  dm-types!
-  dm-validations (= 1.1.0)
+  dm-aggregates (= 1.2.0.rc2)
+  dm-core (= 1.2.0.rc2)
+  dm-is-searchable (= 1.2.0.rc2)
+  dm-is-tree (= 1.2.0.rc2)
+  dm-migrations (= 1.2.0.rc2)
+  dm-mysql-adapter (= 1.2.0.rc2)
+  dm-pager!
+  dm-postgres-adapter (= 1.2.0.rc2)
+  dm-sqlite-adapter (= 1.2.0.rc2)
+  dm-tags (= 1.2.0.rc2)
+  dm-timestamps (= 1.2.0.rc2)
+  dm-types (= 1.2.0.rc2)
+  dm-validations (= 1.2.0.rc2)
   erubis (= 2.6.6)
   haml (= 3.1.1)
   i18n (= 0.5.0)

--- a/lib/lokka.rb
+++ b/lib/lokka.rb
@@ -25,14 +25,14 @@ require 'slim'
 require 'builder'
 require 'nokogiri'
 
-autoload :Theme, 'lokka/theme'
-autoload :User, 'lokka/user'
-autoload :Site, 'lokka/site'
-autoload :Option, 'lokka/option'
-autoload :Entry, 'lokka/entry'
-autoload :Category, 'lokka/category'
-autoload :Comment, 'lokka/comment'
-autoload :Snippet, 'lokka/snippet'
+require 'lokka/theme'
+require 'lokka/user'
+require 'lokka/site'
+require 'lokka/option'
+require 'lokka/entry'
+require 'lokka/category'
+require 'lokka/comment'
+require 'lokka/snippet'
 
 module Lokka
   autoload :Before, 'lokka/before'
@@ -75,6 +75,7 @@ module Lokka
 
   class Database
     def connect
+      DataMapper.finalize
       DataMapper::Logger.new(STDOUT, :debug) if Lokka.development?
       DataMapper.setup(:default, Lokka.config[Lokka.env]['dsn'])
       self
@@ -152,6 +153,12 @@ module DataMapper
         value_length_org(value)
       end
     end
+  end
+end
+
+class Tag
+  def link
+    "/tags/#{name}/"
   end
 end
 


### PR DESCRIPTION
DataMapper 1.2.0.rc2に対応させました．

Gemfileのバージョンを変更する以外に次のような変更をしています．

・すべてのmodelの読み込み後にDataMapper.finalizeを実行する必要があるようになりました．このためmodelのautoloadでの読み込みをrequireに修正しています
・Database#connectでDataMapper.finalizeを呼んでいます
・dm-pagerが1.2.0に対応していないためforkしてgemspecのdependency部分をコメントアウトする一時しのぎの対処をしています
