### PR TITLE
NoMethodError at importer.rb:55

### DIFF
--- a/lib/lokka/importer.rb
+++ b/lib/lokka/importer.rb
@@ -36,7 +36,7 @@ module Lokka
                 Post
               when 'page'
                 Page
-              when 'attachment'
+              else
                 next
               end
 


### PR DESCRIPTION
if `wp:post_type` is not `post`, `page` or `attachment`, variable `model` will be `nil`, and it makes 
`NoMethodError` in line 55.
