### PR TITLE
Fix preview error if updated_at is in entry.erb

### DIFF
--- a/lib/lokka/helpers.rb
+++ b/lib/lokka/helpers.rb
@@ -219,6 +219,7 @@ module Lokka
         @entry = entry
         @entry.user = current_user
         @entry.title << ' - Preview'
+        @entry.updated_at = DateTime.now
         setup_and_render_entry
     end
 


### PR DESCRIPTION
自作テーマの entry.erb に updated_at が含まれていると、プレビュー時にエラーが出るのを修正しました。
