### PR TITLE
Detect conflict on update to reject the later post

### DIFF
--- a/lib/lokka/entry.rb
+++ b/lib/lokka/entry.rb
@@ -23,6 +23,7 @@ class Entry
   validates_presence_of :title
   validates_uniqueness_of :slug
   validates_uniqueness_of :title
+  validates_with_method :updated_at, :method => :conflict?
 
   before :valid? do
     self.category_id = nil if category_id === ''
@@ -81,6 +82,15 @@ class Entry
     return unless @field
     @fields.each do |k, v|
       self.send("#{k}=", v)
+    end
+  end
+
+  def conflict?
+    return true unless id
+    if @updated_at == self.class.get(id).updated_at
+      return true
+    else
+      return [false, "The entry is updated while you were editing"]
     end
   end
 

--- a/lib/lokka/helpers.rb
+++ b/lib/lokka/helpers.rb
@@ -208,7 +208,7 @@ module Lokka
 
     def get_admin_entry_new(entry_class)
       @name = entry_class.name.downcase
-      @entry = entry_class.new(:created_at => DateTime.now)
+      @entry = entry_class.new(:created_at => DateTime.now, :updated_at => DateTime.now)
       @categories = Category.all.map {|c| [c.id, c.title] }.unshift([nil, t('not_select')])
       @field_names = FieldName.all(:order => :name.asc)
       render_any :'entries/new'

--- a/public/admin/entries/form.haml
+++ b/public/admin/entries/form.haml
@@ -46,6 +46,7 @@
     = f.label :created_at, :caption => t("#{@name}.created_at")
     %br/
     = f.text_field :created_at
+  = f.hidden_field :updated_at
   %p
     %input(type="submit" value="#{t('preview')}" name="preview" formtarget="_blank")
     %input(type="submit" value="#{label}" name="edit")


### PR DESCRIPTION
When using lokka in a group like a wiki, conflicting can be a big damage.

Detect conflict by comparing the post's updated_at in DB and sent param's one.
