### PR TITLE
hide edit button if preview

### DIFF
--- a/public/theme/jarvi/entry.erb
+++ b/public/theme/jarvi/entry.erb
@@ -7,7 +7,7 @@
   </div>
   <div class="footer">
     <div class="created_at"><%= l(@entry.created_at, :format => :long) %></div>
-<% if logged_in? %>
+<% if logged_in? && @entry.id %>
     <p><a href="<%= @entry.edit_link %>"><%= t('edit') %></a></p>
 <% end %>
   </div>


### PR DESCRIPTION
Hi,
Thank you great Lokka !

I found that Lokka's preview entry page shows unusable edit button and caused 404 error because the object's id is empty. The edit button on the preview page is not so meaningful and I believe it's better to hide it.

Regards 
