### PR TITLE
fixing top page's index  for contains only non draft pages

### DIFF
--- a/public/theme/jarvi/layout.erb
+++ b/public/theme/jarvi/layout.erb
@@ -23,7 +23,7 @@
       <div class="section">
         <div class="nav">
           <ul class="wide">
-<% Page.all.each do |page| %>
+<% Page.all(:draft => false).each do |page| %>
             <li><a href="<%= page.link %>"><%= page.title %></a></li>
 <% end %>
           </ul>


### PR DESCRIPTION
Hi,

The top page shows draft pages on the index bar.
I believe that it's not good for viewers because they can only see 404 page if they clicked the link.
This patch fixes this behaviour.

Regards.
