### PR TITLE
Remove version specification of bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source :rubygems
 
-gem 'bundler', '~> 1.0.7'
+gem 'bundler'
 gem 'rack', '1.3.6'
 gem 'rack-flash', '0.1.1'
 gem 'i18n', '0.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,7 @@ DEPENDENCIES
   RedCloth (= 4.2.9)
   activesupport (= 3.1.1)
   builder (= 3.0.0)
-  bundler (~> 1.0.7)
+  bundler
   coderay
   data_objects!
   dm-aggregates (= 1.2.0)


### PR DESCRIPTION
I cannot figure out why the version of bundler is limited.

Bundler 1.1 is faster than 1.0, and works perfectlly with lokka.
