### PR TITLE
Fix #123

### DIFF
--- a/lib/lokka/app/admin.rb
+++ b/lib/lokka/app/admin.rb
@@ -340,11 +340,13 @@ module Lokka
     put '/admin/permalink' do
       errors = []
 
-      format = params[:format]
-      format = "/#{format}" unless /^\// =~ format
+      if params[:enable] == "1"
+        format = params[:format]
+        format = "/#{format}" unless /^\// =~ format
 
-      errors << t('permalink.error.no_tags') unless /%.+%/ =~ format
-      errors << t('permalink.error.tag_unclosed') unless format.chars.select{|c| c == '%' }.size.even?
+        errors << t('permalink.error.no_tags') unless /%.+%/ =~ format
+        errors << t('permalink.error.tag_unclosed') unless format.chars.select{|c| c == '%' }.size.even?
+      end
 
       if errors.empty?
         Option.permalink_enabled = (params[:enable] == "1")

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -483,6 +483,13 @@ describe "App" do
         Option.permalink_format.should == "/%year%/%id%"
         Option.permalink_enabled.should == "false"
       end
+
+      it "should turn off custom permalink after once turned on" do
+        put '/admin/permalink', :enable => '1', :format => '/%year%/%slug%'
+        put '/admin/permalink', :enable => '0', :format => ''
+        Option.permalink_enabled.should == 'false'
+        Option.permalink_format.should == ''
+      end
     end
   end
 end


### PR DESCRIPTION
PUT /admin/permalink required permalink format even when turning off the feature.
Now the format is checked only when turning on.
