### PR TITLE
fixed output coverage report.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,3 @@
-# encoding: utf-8
-require File.join(File.dirname(__FILE__), '..', 'init.rb')
-
-require 'rubygems'
-require 'sinatra'
-require 'rack/test'
-require 'rspec'
-require 'factory_girl'
-
-require 'factories'
-
 if RUBY_VERSION >= '1.9'
 
   require 'simplecov'
@@ -23,6 +12,17 @@ if RUBY_VERSION >= '1.9'
     add_filter "log/"
   end
 end
+
+require File.join(File.dirname(__FILE__), '..', 'init.rb')
+
+require 'rubygems'
+require 'sinatra'
+require 'rack/test'
+require 'rspec'
+require 'factory_girl'
+
+require 'factories'
+
 
 set :environment, :test
 Lokka::Database.new.connect


### PR DESCRIPTION
Can't output coverage reports in ruby 1.9.2.
because must SimpleCov.start before require 'lokka'.

in Japanese.
ruby 1.9.2 の環境でカバレッジレポートが正常に出力されていませんでした。
lokkaのコードを読み込む前にSimpleConv.startさせなければ、
プロダクションコードに対するカバレッジは計測できないので、
spec_helper.rbの読み込み順番を修正しました。

これによって、ruby 1.9以降の環境で正常にカバレッジレポートが出力されるようになるはずです。
