### PR TITLE
Enable rake spec to specify target

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -51,7 +51,8 @@ end
 begin
   require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new(:spec => 'spec:setup') do |spec|
-    spec.pattern = 'spec/*_spec.rb'
+    spec_target = ENV['target'] || "*"
+    spec.pattern = "spec/#{spec_target}_spec.rb"
     spec.rspec_opts = ['-cfs']
   end
 rescue LoadError => e

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-if RUBY_VERSION >= '1.9'
+if RUBY_VERSION >= '1.9' && !ENV['target']
 
   require 'simplecov'
 


### PR DESCRIPTION
I don't know how to specify a spec target in lokka.
So I tried to enable rake spec to specify a target.
However, if there are already other ways to specify a spec target, please tell me the way.
Thanks.

Usage Example: rake spec target='user'
