### PR TITLE
Require spec_helper with absolute path using File.expand_path

### DIFF
--- a/spec/integration/admin/categories_spec.rb
+++ b/spec/integration/admin/categories_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe '/admin/categories' do
   include_context 'admin login'

--- a/spec/integration/admin/comments_spec.rb
+++ b/spec/integration/admin/comments_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe '/admin/comments' do
   include_context 'admin login'

--- a/spec/integration/admin/field_names_spec.rb
+++ b/spec/integration/admin/field_names_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe '/admin/field_names' do
   include_context 'admin login'

--- a/spec/integration/admin/others_spec.rb
+++ b/spec/integration/admin/others_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe 'access admin page' do
   include_context 'admin login'

--- a/spec/integration/admin/pages_spec.rb
+++ b/spec/integration/admin/pages_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe '/admin/pages' do
   include_context 'admin login'

--- a/spec/integration/admin/permalink_spec.rb
+++ b/spec/integration/admin/permalink_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe '/admin/permalink' do
   include_context 'admin login'

--- a/spec/integration/admin/posts_spec.rb
+++ b/spec/integration/admin/posts_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe '/admin/posts' do
   include_context 'admin login'

--- a/spec/integration/admin/snippets_spec.rb
+++ b/spec/integration/admin/snippets_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe '/admin/snippets' do
   include_context 'admin login'

--- a/spec/integration/admin/spec_helper.rb
+++ b/spec/integration/admin/spec_helper.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 shared_context "admin login" do
   include_context 'in site'

--- a/spec/integration/admin/tags_spec.rb
+++ b/spec/integration/admin/tags_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe '/admin/tags' do
   include_context 'admin login'

--- a/spec/integration/admin/themes_spec.rb
+++ b/spec/integration/admin/themes_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe 'themes' do
   include_context 'admin login'

--- a/spec/integration/admin/users_spec.rb
+++ b/spec/integration/admin/users_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe '/admin/users' do
   include_context 'admin login'

--- a/spec/integration/app_spec.rb
+++ b/spec/integration/app_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe "App" do
   include_context 'in site'

--- a/spec/integration/login_spec.rb
+++ b/spec/integration/login_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe 'Login' do
   include_context 'in site'

--- a/spec/integration/spec_helper.rb
+++ b/spec/integration/spec_helper.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 shared_context 'in site' do
   before { Factory(:site) }

--- a/spec/unit/category_spec.rb
+++ b/spec/unit/category_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe Category do
   after do

--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe Lokka::Helpers do
   context 'gravatar_image_url' do

--- a/spec/unit/page_spec.rb
+++ b/spec/unit/page_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe Page do
   describe '.first' do

--- a/spec/unit/post_spec.rb
+++ b/spec/unit/post_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe Post do
   after do

--- a/spec/unit/snippet_spec.rb
+++ b/spec/unit/snippet_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe "Snippet" do
   after { Snippet.destroy }

--- a/spec/unit/tag_spec.rb
+++ b/spec/unit/tag_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe 'Tag' do
   after do

--- a/spec/unit/user_spec.rb
+++ b/spec/unit/user_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe "User" do
   after { User.destroy }


### PR DESCRIPTION
In Ruby 1.8, `require` recognizes a file with different relative path as different files.
This made spec_helper required twice, then defined shared_context twice, which threw error.

This is fix for failing CI against Ruby 1.8.
I am not familiar with 1.8, is there a better way to resolve this problem?
