### PR TITLE
consider ending day of month for custom permalink

### DIFF
--- a/lib/lokka/helpers.rb
+++ b/lib/lokka/helpers.rb
@@ -407,7 +407,10 @@ module Lokka
         end
         args = [0,1,1,0,0,0].each_with_index.map{|default,i| args[i] || default }
         conditions[:created_at.gte] = Time.local(*args)
-        args[time_order.index(last)-1] += 1
+        day_end = {:hour => 23, :minute => 59, :second => 59}
+        day_end.each_pair do |key, value|
+          args[time_order.index(key)] = value.to_i
+        end
         conditions[:created_at.lt] = Time.local(*args)
       end
       Entry.first(conditions)

--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -41,7 +41,7 @@ describe Lokka::Helpers do
       it 'should parse date condition' do
         Entry.should_receive(:first).with(:slug => 'slug',
                                      :created_at.gte => Time.local(2011, 1, 9),
-                                     :created_at.lt => Time.local(2011, 1, 10))
+                                     :created_at.lt => Time.local(2011, 1, 9, 23, 59, 59))
         custom_permalink_entry('/2011/01/09/slug')
       end
 


### PR DESCRIPTION
This commit will fix issue #169.

[Issue #169: Custom permalink feature is broken if entry date is end of month · komagata/lokka](https://github.com/komagata/lokka/issues/169)
