### PR TITLE
Fix issue 171: User.random_string never contain '9'

### DIFF
--- a/lib/lokka/user.rb
+++ b/lib/lokka/user.rb
@@ -53,7 +53,7 @@ class User
   end
 
   def self.random_string(len)
-    Array.new(len) { ['a'..'z','A'..'Z','0'..'9'].map(&:to_a).flatten[rand(61)] }.join
+    Array.new(len) { ['a'..'z','A'..'Z','0'..'9'].map(&:to_a).flatten[rand(62)] }.join
   end
 end
 


### PR DESCRIPTION
This pull request fix the [issue 171](https://github.com/komagata/lokka/issues/171)
