### PR TITLE
Format of comment error message is ugly

### DIFF
--- a/public/admin/comments/form.haml
+++ b/public/admin/comments/form.haml
@@ -3,7 +3,7 @@
     #error
       .title= t('error')
       %ul
-        - @comment.errors.each do |error|
+        - @comment.errors.full_messages.each do |error|
           %li= error
   .field
     = f.label :entry, :caption => t('comment.entry')

--- a/public/lokka/comments/form.haml
+++ b/public/lokka/comments/form.haml
@@ -3,7 +3,7 @@
   #error
     .title= t('error')
     %ul
-      - @comment.errors.each do |error|
+      - @comment.errors.full_messages.each do |error|
         %li= error
 - form_for @comment, request.path_info, :method => :post do |f|
   :javascript

--- a/public/theme/Farikal/entry.haml
+++ b/public/theme/Farikal/entry.haml
@@ -35,7 +35,7 @@
             #error
               .title= t('error')
               %ul
-                - @comment.errors.each do |error|
+                - @comment.errors.full_messages.each do |error|
                   %li= error
           - form_for @comment, request.path_info, :method => :post do |f|
             :javascript

--- a/public/theme/harmaa/entry.haml
+++ b/public/theme/harmaa/entry.haml
@@ -35,7 +35,7 @@
         #error
           .title= t('error')
           %ul
-            - @comment.errors.each do |error|
+            - @comment.errors.full_messages.each do |error|
               %li= error
       - form_for @comment, request.path_info, :method => :post do |f|
         :javascript


### PR DESCRIPTION
Format of comment error message is ugly (examples are shown below).

This commit fixes that.

https://dl.dropbox.com/u/1790207/github/%E3%82%B9%E3%82%AF%E3%83%AA%E3%83%BC%E3%83%B3%E3%82%B7%E3%83%A7%E3%83%83%E3%83%88%202012-08-03%2012.56.04.png
https://dl.dropbox.com/u/1790207/github/%E3%82%B9%E3%82%AF%E3%83%AA%E3%83%BC%E3%83%B3%E3%82%B7%E3%83%A7%E3%83%83%E3%83%88%202012-08-03%2012.39.44.png
