### PR TITLE
Ruby2.0.0でOptionのsave, restoreが出来るようにした

### DIFF
--- a/lib/lokka/option.rb
+++ b/lib/lokka/option.rb
@@ -14,7 +14,7 @@ class Option
     if attribute =~ /=$/
       column = attribute[0, attribute.size - 1]
       o = self.first_or_new(:name => column)
-      o.value = args.first
+      o.value = args.first.to_s
       o.save
     else
       o = self.first_or_new(:name => method.to_s)


### PR DESCRIPTION
Optionの保存とリストアがRuby2.0.0で動くようにした。挙動としては動いているが、どの変更でこうなっているのかよくわかっていないのでちょっと不安。dm-coreはどちらも`1.2.0`
直すべきはDataMapper側かもしれない

```
value
Ruby1.9.3
Booleanで保存してStringで取り出せていた
Ruby2.0.0
Stringで保存する必要がある
```

```
name
Ruby1.9.3
keyがStringでもSymbolでも取り出せていた
Ruby2.0.0
keyがStringでないと取り出せない
```
