### PR TITLE
Add default markup in admin/site/edit

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -175,6 +175,7 @@ en:
     per_page: Number per page
     default_sort: Default sort
     default_order: Default order
+    default_markup: Default markup
     meta_description: Meta description
     meta_keywords: Meta keywords
     created_at: Created at

--- a/i18n/ja.yml
+++ b/i18n/ja.yml
@@ -175,6 +175,7 @@ ja:
     per_page: 表示件数
     default_sort: デフォルトのソート対象
     default_order: デフォルトのソート順
+    default_markup: デフォルトのMarkup
     meta_description: メタディスクリプション
     meta_keywords: メタキーワード
     created_at: 作成日時

--- a/lib/lokka/helpers.rb
+++ b/lib/lokka/helpers.rb
@@ -149,7 +149,7 @@ module Lokka
 
     def get_admin_entry_new(entry_class)
       @name = entry_class.name.downcase
-      @entry = entry_class.new(:created_at => DateTime.now, :updated_at => DateTime.now)
+      @entry = entry_class.new(:markup => Site.first.default_markup, :created_at => DateTime.now, :updated_at => DateTime.now)
       @categories = Category.all.map {|c| [c.id, c.title] }.unshift([nil, t('not_select')])
       @field_names = FieldName.all(:order => :name.asc)
       haml :'admin/entries/new', :layout => :'admin/layout'

--- a/lib/lokka/site.rb
+++ b/lib/lokka/site.rb
@@ -14,6 +14,7 @@ class Site
   property :per_page, Integer
   property :default_sort, String, :length => 255
   property :default_order, String, :length => 255
+  property :default_markup, String, :length => 255
   property :meta_description, String, :length => 255
   property :meta_keywords, String, :length => 255
   property :created_at, DateTime

--- a/public/admin/site/edit.haml
+++ b/public/admin/site/edit.haml
@@ -1,6 +1,7 @@
 :ruby
   sort_options  = Site::SORT_COLUMNS.map {|c| [t("entry.#{c}"), c] }
   order_options = Site::ORDERS.map {|o| [t(o), o] }
+  markup_options = Markup.engine_list.map {|e| [e[1], e[0]] }
 %h2= t('edit_site')
 - form_for @site, url('/admin/site'), :method => :put do |f|
   %p
@@ -27,6 +28,10 @@
     = f.label :default_order, :caption => t('site.default_order')
     %br/
     = f.select :default_order, :options => order_options
+  %p
+    = f.label :default_markup, :caption => t('site.default_markup')
+    %br/
+    = f.select :default_markup, :options => markup_options
   %p
     = f.label :meta_description
     %br/

--- a/spec/integration/admin/posts_spec.rb
+++ b/spec/integration/admin/posts_spec.rb
@@ -31,6 +31,18 @@ describe '/admin/posts' do
       get '/admin/posts/new'
       last_response.body.should match('<form')
     end
+
+    Markup.engine_list.map(&:first).each do |markup|
+      context "when #{markup} is set a default markup" do
+        before { Site.first.update(:default_markup => markup) }
+        after { Site.first.update(:default_markup => nil) }
+
+        it "should select #{markup}" do
+          get '/admin/posts/new'
+          last_response.body.should match(%Q[value="#{markup}" selected="selected">])
+        end
+      end
+    end
   end
 
   context 'POST /admin/posts' do


### PR DESCRIPTION
I would like to add 'Default markup' in admin/site/edit.

![default_markup](https://f.cloud.github.com/assets/26753/159744/7f7f7002-773d-11e2-90c8-d2db8d5e5042.png)
