### PR TITLE
Remove sequential double quote

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
   factory :site do
     title 'Test Site'
     description 'description...'
-    dashboard %q(<p>Welcome to Lokka!</p><p>To post a new article, choose ""<a href=""/admin/posts/new"">New</a>"" under ""Posts"" on the menu to the left. To change the title of the site, choose ""Settings"" on the menu to the left. (The words displayed here can be changed anytime through the ""<a href=""/admin/site/edit"">Settings</a>"" screen.)</p>)
+    dashboard %q(<p>Welcome to Lokka!</p><p>To post a new article, choose "<a href=\"/admin/posts/new\">New</a>" under "Posts" on the menu to the left. To change the title of the site, choose "Settings" on the menu to the left. (The words displayed here can be changed anytime through the "<a href=\"/admin/site/edit\">Settings</a>" screen.)</p>)
     theme 'jarvi'
     created_at create_time
     updated_at update_time
@@ -24,7 +24,7 @@ FactoryGirl.define do
   factory :post do
     association :user
     sequence(:title){|n| "Test Post #{n}" }
-    body "<p>Welcome to Lokka!</p><p><a href=""/admin/"">Admin login</a> (user / password : test / test)</p>"
+    body '<p>Welcome to Lokka!</p><p><a href="/admin/">Admin login</a> (user / password : test / test)</p>'
     type 'Post'
     created_at create_time
     updated_at update_time
@@ -33,7 +33,7 @@ FactoryGirl.define do
   factory :entry do
     association :user
     sequence(:title){|n| "Test Post #{n}" }
-    body "<p>Welcome to Lokka!</p><p><a href=""/admin/"">Admin login</a> (user / password : test / test)</p>"
+    body '<p>Welcome to Lokka!</p><p><a href="/admin/">Admin login</a> (user / password : test / test)</p>'
     type 'Post'
     created_at create_time
     updated_at update_time


### PR DESCRIPTION
I found that in some case sequentila double quotes will cause rspec failure.

For instance, when I run spec with Ruby 2.1.0 on wercker, I got error below.

``` sh
Failures:

  1) Post markup default should == "<p>Welcome to Lokka!</p><p><a href=/admin/>Admin login</a> (user / password : test / test)</p>"
     Failure/Error: it { post.body.should == post.raw_body }
       expected: "<p>Welcome to Lokka!</p><p><a href=/admin/>Admin login</a> (user / password : test / test)</p>"
            got: "<p>Welcome to Lokka!</p><p><a href=\"/admin/\">Admin login</a> (user / password : test / test)</p>" (using ==)
     # ./spec/unit/post_spec.rb:56:in `block (4 levels) in <top (required)>'
```

It might be because sequential double quotes apear in `spec/factories.rb`. This pull request deletes them.

For more information, please take a look at [my blog post](http://www.portalshit.net/2014/02/21/how-ruby-treat-sequential-double-quote).
