### PR TITLE
Fix bug fails to update tags

### DIFF
--- a/lib/lokka/models/entry.rb
+++ b/lib/lokka/models/entry.rb
@@ -48,10 +48,13 @@ class Entry
   end
 
   def tag_collection=(string)
-    reg = RUBY_VERSION >= "1.9.0" ? /[^\p{Word}._]/iu : /[^\w\s._-]/i
-    @tag_list = string.to_s.split(',').map { |name|
-      name.force_encoding(Encoding.default_external).gsub(reg, '').strip
-    }.reject{|x|x.blank?}.uniq.sort
+    reg = /[^\p{Word}._]/iu
+    @tag_list = string.to_s.split(",").map { |name|
+      name.force_encoding(Encoding.default_external).gsub(reg, "").strip
+    }
+    @tag_list = @tag_list.reject(&:blank?).uniq.sort
+
+    update_tags
   end
 
   def fuzzy_slug
@@ -142,20 +145,20 @@ class Entry
       ret = first({:slug => str}.update(query))
       ret.blank? ? first({:id => str}.update(query)) : ret
     end
-  
+
     def search(str)
       all(:title.like => "%#{str}%") |
         all(:body.like => "%#{str}%")
     end
-  
+
     def recent(count = 5)
       all(:draft => false, :limit => count)
     end
-  
+
     def published
       all(:draft => false)
     end
-  
+
     def unpublished
       all(:draft => true)
     end

--- a/spec/unit/post_spec.rb
+++ b/spec/unit/post_spec.rb
@@ -86,4 +86,12 @@ describe Post do
     before { build :post }
     it { expect { Post.first }.not_to raise_error }
   end
+
+  describe "#tag_collection=" do
+    let(:entry) { create(:entry) }
+    before { entry.tag_collection = "foo,bar" }
+    it "should update tags" do
+      expect { entry.save }.to change { entry.tags }
+    end
+  end
 end


### PR DESCRIPTION
tag が記事の更新時に保存されないというバグを修正しました。

dm-tags.gem に Taggable なモデル（ Lokka では Entry モデル）の更新時にタグが保存されないというバグがあります。この問題は `Taggable#tag_collection=` メソッドを修正すれば直るのですが、 Lokka では `Taggable#tag_collection=` メソッドが Entry モデルでオーバーライドされています。なので `#tag_collection=` メソッド内でタグのインスタンスを更新する処理を呼ぶようにしました。これで Entry のタグが更新時に保存されるようになります。