### PR TITLE
Enable database encoding configuration

### DIFF
--- a/database.default.yml
+++ b/database.default.yml
@@ -1,3 +1,5 @@
+# Configurable by DSN or YAML Hash
+#
 # DSN (Data Source Name) examples
 #
 # sqlite3:
@@ -8,8 +10,30 @@
 #   postgres://user:pass@host/database
 # heroku:
 #   <%= ENV['DATABASE_URL'] %>
+#
+# Hash example
+#
+# production:
+#   adapter: mysql
+#   database: database
+#   username: user
+#   password: pass
+#   host: host
+#   encoding: UTF-8-MB4
+#
+# which is equivalent to
+#
+# production:
+#   dsn: mysql://user:pass@host/database
+#
 production:
   dsn: <%= ENV['DATABASE_URL'] %>
+  # adapter:  <%= ENV['DATABASE_ADAPTER'] %>
+  # database: <%= ENV['DATABASE_NAME'] %>
+  # username: <%= ENV['DATABASE_USER'] %>
+  # password: <%= ENV['DATABASE_PASSWORD'] %>
+  # host:     <%= ENV['DATABASE_HOST'] %>
+  # encoding: UTF-8-MB4
 development:
   dsn: sqlite3://<%= root %>/db/development.sqlite3
 test:

--- a/lib/lokka.rb
+++ b/lib/lokka.rb
@@ -27,8 +27,20 @@ module Lokka
     #
     # @return [String] DSN (Data Source Name) is configuration for database.
     def dsn
+      database_config['dsn']
+    end
+
+    ##
+    # Data Source Hash
+    #
+    # @return [Hash] DSH (Data Source Hash) is configuration for database.
+    def dsh
+      database_config.dup.delete_if {|key, _| key == 'dsn' }
+    end
+
+    def database_config
       filename = File.exist?("#{Lokka.root}/database.yml") ? 'database.yml' : 'database.default.yml'
-      YAML.load(ERB.new(File.read("#{Lokka.root}/#{filename}")).result(binding))[self.env]['dsn']
+      YAML.load(ERB.new(File.read("#{Lokka.root}/#{filename}")).result(binding))[self.env]
     end
 
     ##

--- a/lib/lokka/database.rb
+++ b/lib/lokka/database.rb
@@ -4,7 +4,12 @@ module Lokka
 
     def connect
       DataMapper.finalize
-      DataMapper.setup(:default, Lokka.dsn)
+      config = if Lokka.dsn.present?
+                 Lokka.dsn
+               else
+                 Lokka.dsh
+               end
+      DataMapper.setup(:default, config)
       self
     end
 


### PR DESCRIPTION
Enables to configure database encoding. That makes it possible to use utf8mb4 with MySQL so that everybody can write their blog with emoji 🎉