### PR TITLE
Ignore vendor dir on Docker container to reduce container image size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     volumes:
       - .:/app
       - bundle:/usr/local/bundle
+      - app_bundle:/app/.bundle
+      - vendor:/app/vendor
     ports:
       - "9292:9292"
     depends_on:
@@ -25,3 +27,5 @@ services:
 volumes:
   data-volume:
   bundle:
+  app_bundle:
+  vendor:


### PR DESCRIPTION
## Problem

If gems are installed to `vendor/bundle` dir locally, `vendor/` dir are shared between guest and host. That's insufficient because `vendor/bundle` dir is not used from app running on container.

## How to solve

- create virtual volume for `vendor/` directory not to share locally installed gems
- create virtual volume for `.bundle/` directory not to share `.bundle/config`

### Before

<img width="612" alt="Screen Shot 2019-09-07 at 11 06 01" src="https://user-images.githubusercontent.com/106567/64469123-e5dfd900-d167-11e9-96bf-41c8c0dc879c.png">

### After

<img width="755" alt="Screen Shot 2019-09-07 at 11 08 22" src="https://user-images.githubusercontent.com/106567/64469129-ef694100-d167-11e9-93f2-f2419e34e36e.png">

It may reduce container image size at least 100MB if developer sets `--path vendor/bundle` option while bundle install.