### PR TITLE
Bump up RSpec to 2.99

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ group :test do
   gem 'dm-transactions', '~> 1.2.0'
   gem 'factory_girl', '~> 4.0'
   gem 'rack-test', '0.6.1', require: 'rack/test'
-  gem 'rspec', '2.14.1'
+  gem 'rspec', '~> 2.0'
   gem 'simplecov', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,14 +165,14 @@ GEM
       rack (>= 1.0)
       rack-test (>= 0.5)
       ripl (>= 0.3.5)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.8)
-    rspec-expectations (2.14.5)
+    rspec (2.99.0)
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
+    rspec-core (2.99.2)
+    rspec-expectations (2.99.2)
       diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.6)
+    rspec-mocks (2.99.4)
     rubocop (0.52.1)
       parallel (~> 1.10)
       parser (>= 2.4.0.2, < 3.0)
@@ -268,7 +268,7 @@ DEPENDENCIES
   rake (~> 12.3)
   redcarpet
   request_store
-  rspec (= 2.14.1)
+  rspec (~> 2.0)
   rubocop
   sass
   simplecov
@@ -282,4 +282,4 @@ DEPENDENCIES
   yard-sinatra (= 1.0.0)
 
 BUNDLED WITH
-   2.0.2
+   2.1.2

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,13 @@ require 'yard'
 
 task default: ['spec:setup', 'db:delete', :spec]
 
+module TempFixForRakeLastComment
+  def last_comment
+    last_description
+  end
+end
+Rake::Application.include(TempFixForRakeLastComment)
+
 desc 'Migrate the Lokka database'
 task 'db:migrate' do
   puts 'Upgrading Database...'


### PR DESCRIPTION
## The Problem

- As Rake has vulnerability. So I merged https://github.com/lokka/lokka/pull/248 from dependabot.
- #248 bumped up rake to 12.3.3, the version of rake dropped `Rake::Application.last_comment`
- Lokka use's ancient RSpec, it can't live with `Rake::Application.last_comment`

## The Solution

- Bump up RSpec to 2.99 which is compatible with recent version of Rake
- Add a workaround that fix the `NoMethodError: undefined method `last_comment'` problem