### PR TITLE
Bump up ActiveSupport to 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'activesupport', '~> 4.2'
+gem 'activesupport', '~> 5.0'
 gem 'aws-sdk-s3'
 gem 'backports', '2.3.0'
 gem 'builder'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,10 +10,10 @@ GEM
   remote: https://rubygems.org/
   specs:
     RedCloth (4.2.9)
-    activesupport (4.2.10)
-      i18n (~> 0.7)
+    activesupport (5.2.4.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
@@ -55,7 +55,7 @@ GEM
       sass (>= 3.3.0, < 3.5)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.6)
     data_objects (0.10.17)
       addressable (~> 2.1)
     database_cleaner (0.7.1)
@@ -122,14 +122,14 @@ GEM
       rake (>= 10, < 13)
       rubocop (>= 0.50.0)
       sysexits (~> 1.1)
-    i18n (0.9.1)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     jmespath (1.3.1)
     json (1.8.6)
     kramdown (1.15.0)
     mimemagic (0.3.2)
     mini_portile2 (2.4.0)
-    minitest (5.10.3)
+    minitest (5.14.0)
     multi_json (1.12.2)
     nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
@@ -216,7 +216,7 @@ GEM
       ripl-multi_line (>= 0.2.4)
       ripl-rack (>= 0.2.0)
       sinatra (>= 1.2.1)
-    tzinfo (1.2.4)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
     unicode-display_width (1.3.0)
     uuidtools (2.1.5)
@@ -229,7 +229,7 @@ PLATFORMS
 
 DEPENDENCIES
   RedCloth (= 4.2.9)
-  activesupport (~> 4.2)
+  activesupport (~> 5.0)
   aws-sdk-s3
   backports (= 2.3.0)
   builder

--- a/lib/lokka/models/entry.rb
+++ b/lib/lokka/models/entry.rb
@@ -121,25 +121,27 @@ class Entry
     desc.gsub(%r{<[^/]+/>}, ' ').gsub(%r{</[^/]+>}, ' ').gsub(/<[^>]+>/, '').html_safe
   end
 
-  class << self
+  module FinderstWithScope
     def _default_scope
       { order: :created_at.desc }
     end
 
-    def first_with_scope(limit = 1, query = DataMapper::Undefined)
+    def first(limit = 1, query = DataMapper::Undefined)
       query = limit unless limit.is_a? Integer
       query = _default_scope.update(query) if query.is_a? Hash
       query = _default_scope if query == DataMapper::Undefined
-      first_without_scope query
+      super(query)
     end
-    alias_method_chain :first, :scope
 
-    def all_with_scope(query = DataMapper::Undefined)
+    def all(query = DataMapper::Undefined)
       query = _default_scope.update(query) if query.is_a? Hash
       query = _default_scope if query == DataMapper::Undefined
-      all_without_scope query
+      super(query)
     end
-    alias_method_chain :all, :scope
+  end
+
+  class << self
+    prepend FinderstWithScope
 
     def get_by_fuzzy_slug(str, query = {})
       query = { draft: false }.update(query)

--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -42,10 +42,8 @@ describe Lokka::Helpers do
 
     describe 'custom_permalink_entry' do
       it 'should parse date condition' do
-        Entry.should_receive(:first).with(slug: 'slug',
-                                          :created_at.gte => Time.local(2011, 1, 9),
-                                          :created_at.lt => Time.local(2011, 1, 9, 23, 59, 59))
-        custom_permalink_entry('/2011/01/09/slug')
+        entry = create(:entry, created_at: '2011-01-09T23:45:45', slug: 'slug')
+        expect(custom_permalink_entry('/2011/01/09/slug')).to eq(entry)
       end
 
       it 'should return nil when any error is raised' do


### PR DESCRIPTION
## The Problem

- `NoMethodError: undefined method new for BigDecimal:Class`
  `BigDecimal.new` is deprecated and has been removed in the recent version of Ruby
  https://github.com/ruby/ruby/blob/v2_6_0/NEWS#stdlib-updates-outstanding-ones-only-
- alias_method_chain is deprecated and can't be used in ActiveSupport 6

## The Solution

- Bump up ActiveSupport to ver 5
- Replace alias_method_chain with Module.prepend
  - Also update the relevant test case that checks `custom_permalink_entry` behavior