### PR TITLE
Specify Ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+ruby "~> 2.4"
 
 gem 'activesupport', '~> 5.0'
 gem 'aws-sdk-s3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,5 +281,8 @@ DEPENDENCIES
   tux
   yard-sinatra (= 1.0.0)
 
+RUBY VERSION
+   ruby 2.7.0p0
+
 BUNDLED WITH
    2.1.2


### PR DESCRIPTION
## The Problem

Cannot deploy lokka to heroku without specifying Ruby version. Current master branch expects  bundler 2 have been installed, but without specifying Ruby version, heroku will use older version of ruby that is not compatible with bundler 2.

## The Solution

Specifying the lowest ruby version ( `ruby "~> 2.4"` ) on Gemfile.