### PR TITLE
Make `docker compose up` work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5-alpine
+FROM ruby:2.6-alpine
 
 RUN mkdir -p /app
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
+    platform: linux/amd64
     volumes:
       - data-volume:/var/lib/mysql
   app:
@@ -17,7 +18,6 @@ services:
     command: ["bundle", "exec", "rackup", "-o", "0.0.0.0"]
     volumes:
       - .:/app
-      - bundle:/usr/local/bundle
       - app_bundle:/app/.bundle
       - vendor:/app/vendor
     ports:


### PR DESCRIPTION
I made it work because it didn't work when I did docker compose up.

```
$ docker compose up
[+] Running 2/0
 ⠿ Container blog-db-1   Created                                                                                                                                                                                                            0.0s
 ⠿ Container blog-app-1  Recreated                                                                                                                                                                                                          0.1s
Attaching to blog-app-1, blog-db-1
blog-db-1   | 2022-10-10 08:10:44+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 5.7.39-1.el7 started.
blog-app-1  | Your RubyGems version (3.0.3) has a bug that prevents `required_ruby_version` from working for Bundler. Any scripts that use `gem install bundler` will break as soon as Bundler drops support for your Ruby version. Please upgrade RubyGems to avoid future breakage and silence this warning by running `gem update --system 3.2.3`
blog-app-1  | bundler: failed to load command: rackup (/usr/local/bundle/bin/rackup)
blog-app-1  | /usr/local/bundle/gems/bundler-2.3.23/lib/bundler/definition.rb:433:in `validate_ruby!': Your Ruby version is 2.5.9, but your Gemfile specified ~> 2.6 (Bundler::RubyVersionMismatch)
blog-app-1  |   from /usr/local/bundle/gems/bundler-2.3.23/lib/bundler/definition.rb:408:in `validate_runtime!'
blog-app-1  |   from /usr/local/bundle/gems/bundler-2.3.23/lib/bundler.rb:156:in `setup'
blog-app-1  |   from /usr/local/bundle/gems/bundler-2.3.23/lib/bundler/setup.rb:20:in `block in <top (required)>'
blog-app-1  |   from /usr/local/bundle/gems/bundler-2.3.23/lib/bundler/ui/shell.rb:136:in `with_level'
blog-app-1  |   from /usr/local/bundle/gems/bundler-2.3.23/lib/bundler/ui/shell.rb:88:in `silence'
blog-app-1  |   from /usr/local/bundle/gems/bundler-2.3.23/lib/bundler/setup.rb:20:in `<top (required)>'
blog-app-1  |   from /usr/local/bundle/gems/bundler-2.3.23/lib/bundler/cli/exec.rb:56:in `require_relative'
blog-app-1  |   from /usr/local/bundle/gems/bundler-2.3.23/lib/bundler/cli/exec.rb:56:in `kernel_load'
blog-app-1  |   from /usr/local/bundle/gems/bundler-2.3.23/lib/bundler/cli/exec.rb:23:in `run'
blog-app-1  |   from /usr/local/bundle/gems/bundler-2.3.23/lib/bundler/cli.rb:486:in `exec'
blog-app-1  |   from /usr/local/bundle/gems/bundler-2.3.23/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
blog-app-1  |   from /usr/local/bundle/gems/bundler-2.3.23/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
blog-app-1  |   from /usr/local/bundle/gems/bundler-2.3.23/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
blog-app-1  |   from /usr/local/bundle/gems/bundler-2.3.23/lib/bundler/cli.rb:31:in `dispatch'
blog-app-1  |   from /usr/local/bundle/gems/bundler-2.3.23/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
blog-app-1  |   from /usr/local/bundle/gems/bundler-2.3.23/lib/bundler/cli.rb:25:in `start'
blog-app-1  |   from /usr/local/bundle/gems/bundler-2.3.23/exe/bundle:48:in `block in <top (required)>'
blog-app-1  |   from /usr/local/bundle/gems/bundler-2.3.23/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
blog-app-1  |   from /usr/local/bundle/gems/bundler-2.3.23/exe/bundle:36:in
```


