### PR TITLE
Use double quote in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ RUN apk add --no-cache alpine-sdk \
 COPY . /app
 COPY Gemfile.docker /app/Gemfile
 
-CMD ['bundle', 'exec', 'rackup', '-o', '0.0.0.0']
+CMD ["bundle", "exec", "rackup", "-o", "0.0.0.0"]


### PR DESCRIPTION
before

```shell
$ docker build -t lokka .
$ docker run -it --rm lokka
/bin/sh: [bundle,: not found
```

after

```shell
$ docker build -t lokka .
$ docker run -it --rm lokka
Your RubyGems version (3.0.3) has a bug that prevents `required_ruby_version` from working for Bundler. Any scripts that use `gem install bundler` will break as soon as Bundler drops support for your Ruby version. Please upgrade RubyGems to avoid future breakage and silence this warning by running `gem update --system 3.2.3`
[2022-10-12 22:29:31] INFO  WEBrick 1.4.2.1
[2022-10-12 22:29:31] INFO  ruby 2.5.9 (2021-04-05) [aarch64-linux-musl]
[2022-10-12 22:29:31] INFO  WEBrick::HTTPServer#start: pid=1 port=9292

```