### PR TITLE
docker 環境で起動できるようにする仮修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
 FROM ruby:2.6-alpine
 
+ENV RUBYGEMS_VERSION=2.7.6
+ENV BUNDLER_VERSION=1.16.6
+
 RUN mkdir -p /app
 WORKDIR /app
 
 COPY Gemfile.docker /app/Gemfile
 COPY Gemfile.lock /app/
 
-RUN gem install bundler
+RUN gem install bundler -v ${BUNDLER_VERSION}
 RUN apk add --no-cache bash nodejs mysql-client mysql-dev sqlite-dev less
 RUN apk add --no-cache alpine-sdk \
       --virtual .build_deps libxml2-dev libxslt-dev zlib zlib-dev \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,4 +289,4 @@ RUBY VERSION
    ruby 2.7.0p0
 
 BUNDLED WITH
-   2.1.2
+   1.16.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   db:
     image: mysql:5.7
     ports:
-      - "3306:3306"
+      - ${LOKKA_DB_PORT:-3306}:3306
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
@@ -11,7 +11,7 @@ services:
     volumes:
       - data-volume:/var/lib/mysql
   app:
-    image: lokka/lokka
+    # image: lokka/lokka
     environment:
       DB_HOST: db
     build: .
@@ -21,7 +21,7 @@ services:
       - app_bundle:/app/.bundle
       - vendor:/app/vendor
     ports:
-      - "9292:9292"
+      - ${LOKKA_APP_PORT:-9292}:9292
     depends_on:
       - db
 volumes:


### PR DESCRIPTION
公式最新版のままでは起動できなかったので、一先ず自分の環境で起動できるように実装を整える。

元々起動できなかった原因が不明瞭なので、原因調査は必要。しかし、数年単位でメンテナンスされていないので、当時は起動できたが環境変化で起動不能になったのか、元々作業途中だったのかは、もはや追及できないかもしれない。