### PR TITLE
Add Gyazo image upload plugin

### DIFF
--- a/public/plugin/lokka-gyazo/lib/lokka/gyazo.rb
+++ b/public/plugin/lokka-gyazo/lib/lokka/gyazo.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'net/http'
+
+module Lokka
+  module Gyazo
+    UPLOAD_URI = URI('https://upload.gyazo.com/api/upload')
+
+    def self.registered(app)
+      app.get '/admin/plugins/gyazo' do
+        login_required
+        erb :'plugin/lokka-gyazo/views/index', layout: :'admin/layout'
+      end
+
+      app.put '/admin/plugins/gyazo' do
+        login_required
+        Option.gyazo_access_token = params[:gyazo_access_token]
+        flash[:notice] = 'Updated.'
+        redirect to('/admin/plugins/gyazo')
+      end
+
+      app.post '/admin/attachments' do
+        pass if gyazo_access_token.blank?
+        login_required
+        content_type :json
+
+        result = upload_to_gyazo(params[:file])
+        status result[:status]
+        result.to_json
+      end
+    end
+  end
+
+  module Helpers
+    def gyazo_access_token
+      ENV['GYAZO_ACCESS_TOKEN'].presence || Option.gyazo_access_token
+    end
+
+    def upload_to_gyazo(file)
+      return { message: 'No image file', status: 400 } unless file&.dig(:type)&.start_with?('image/')
+
+      request = Net::HTTP::Post.new(Gyazo::UPLOAD_URI)
+      request['Authorization'] = "Bearer #{gyazo_access_token}"
+      request.set_form(
+        [['imagedata', file[:tempfile], { filename: file[:filename], content_type: file[:type] }]],
+        'multipart/form-data'
+      )
+      response = Net::HTTP.start(Gyazo::UPLOAD_URI.host, Gyazo::UPLOAD_URI.port, use_ssl: true).request(request)
+      body = JSON.parse(response.body)
+
+      unless response.code.start_with?('2')
+        return { message: body['message'] || 'Gyazo upload failed', status: response.code.to_i }
+      end
+
+      { message: 'File upload success', url: body.fetch('url'), status: 201 }
+    rescue JSON::ParserError, KeyError, SocketError, SystemCallError, Timeout::Error => e
+      { message: e.message, status: 502 }
+    end
+  end
+end

--- a/public/plugin/lokka-gyazo/views/index.erb
+++ b/public/plugin/lokka-gyazo/views/index.erb
@@ -1,0 +1,13 @@
+<h2>Gyazo</h2>
+<p>When an access token is configured, images dropped or pasted into the editor are uploaded to Gyazo.</p>
+<form action="<%= url('/admin/plugins/gyazo') %>" method="post">
+  <input type="hidden" name="_method" value="put">
+  <div class="field">
+    <label for="gyazo_access_token">Access token</label>
+    <br>
+    <input type="password" id="gyazo_access_token" name="gyazo_access_token" value="<%= Option.gyazo_access_token %>">
+  </div>
+  <p>
+    <input type="submit" value="<%= t('save') %>">
+  </p>
+</form>

--- a/test/integration/gyazo_test.rb
+++ b/test/integration/gyazo_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require_relative '../support/admin_helper'
+
+class GyazoTest < LokkaTestCase
+  include AdminLoginContext
+
+  def test_get_settings_page
+    get '/admin/plugins/gyazo'
+
+    assert last_response.ok?
+    assert_includes last_response.body, 'gyazo_access_token'
+  end
+
+  def test_settings_page_saves_access_token
+    put '/admin/plugins/gyazo', gyazo_access_token: 'token'
+
+    assert last_response.redirect?
+    assert_equal 'token', Option.gyazo_access_token
+  end
+
+  def test_uploads_image_to_gyazo
+    Option.gyazo_access_token = 'token'
+    response = Struct.new(:body, :code).new('{"url":"https://i.gyazo.com/image.png"}', '200')
+    client = Struct.new(:response) do
+      def request(_request)
+        response
+      end
+    end.new(response)
+    file = Rack::Test::UploadedFile.new(File.join(fixture_path, '1px.gif'), 'image/gif')
+
+    Net::HTTP.stub(:start, client) do
+      post '/admin/attachments', file: file
+    end
+
+    assert_equal 201, last_response.status
+    assert_equal 'https://i.gyazo.com/image.png', JSON.parse(last_response.body)['url']
+  end
+end


### PR DESCRIPTION
## Summary

Add a plugin that uploads images dropped or pasted into the post and page editor to Gyazo when an access token is configured.

The existing upload and editor insertion flow is reused, so the returned Gyazo URL is inserted using Markdown, HTML, or Textile according to the selected markup.

## Verification

- `bundle exec rake test`
- `bundle exec rubocop public/plugin/lokka-gyazo/lib/lokka/gyazo.rb test/integration/gyazo_test.rb`